### PR TITLE
Fixing https://github.com/adorsys/xs2a/issues/27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <mariadb.version>2.3.0</mariadb.version>
         <h2.version>1.4.197</h2.version>
         <snakeyaml.version>1.23</snakeyaml.version>
-        <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.el.version>3.0.1-b09</javax.el.version>
         <javax.el-api.version>3.0.0</javax.el-api.version>

--- a/xs2a-impl/src/main/java/de/adorsys/psd2/xs2a/component/MultiReadHttpServletRequest.java
+++ b/xs2a-impl/src/main/java/de/adorsys/psd2/xs2a/component/MultiReadHttpServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2018 adorsys GmbH & Co KG
+ * Copyright 2018-2019 adorsys GmbH & Co KG
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package de.adorsys.psd2.xs2a.component;
 
 import org.apache.commons.io.IOUtils;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
@@ -52,7 +53,7 @@ public class MultiReadHttpServletRequest extends HttpServletRequestWrapper {
         IOUtils.copy(super.getInputStream(), cachedBytes);
     }
 
-    public class CachedServletInputStream extends ServletInputStream {
+    private class CachedServletInputStream extends ServletInputStream {
         private ByteArrayInputStream input;
 
         public CachedServletInputStream() {
@@ -63,5 +64,22 @@ public class MultiReadHttpServletRequest extends HttpServletRequestWrapper {
         public int read() {
             return input.read();
         }
+
+		@Override
+		public boolean isFinished() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		@Override
+		public boolean isReady() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		@Override
+		public void setReadListener(ReadListener readListener) {
+			// TODO Auto-generated method stub
+		}
     }
 }


### PR DESCRIPTION
This fixes https://github.com/adorsys/xs2a/issues/27, after it's applied, `spi-mock` runs again without problems.