### PR TITLE
Update GETTING_STARTED.md

### DIFF
--- a/doc/GETTING_STARTED.md
+++ b/doc/GETTING_STARTED.md
@@ -79,7 +79,7 @@ $ mvn liquibase:update
 Now, once PostgreSQL-server is running on port `5432` you may run consent-management-system server:
 ```bash
 $ cd consent-management/cms-standalone-service
-$ mvn -Drun.arguments=--server_key=12345678 spring-boot:run
+$ mvn spring-boot:run -Dspring-boot.run.arguments=--server_key=12345678
 ```
 Open a browser on page [http://localhost:38080/swagger-ui.html](http://localhost:38080/swagger-ui.html)
 


### PR DESCRIPTION
mvn spring-boot:run -Drun.arguments=--server_key=12345678

2019-06-11 16:20:08.732  INFO 49424 --- [           main] d.a.p.c.s.security.SecurityDataService   : The 'server_key' missing - must be specified at CMS start
CMS_SERVER_KEY_MISSING

Solution : For Spring Boot 2.x, we can pass the arguments using -Dspring-boot.run.arguments :

mvn spring-boot:run -Dspring-boot.run.arguments=--server_key=12345678