### PR TITLE
fix: mapping common-payment-iid instead of payment-pata-id on bulk-payment

### DIFF
--- a/consent-management/consent-management-lib/src/main/java/de/adorsys/psd2/consent/service/mapper/CmsPsuPisMapper.java
+++ b/consent-management/consent-management-lib/src/main/java/de/adorsys/psd2/consent/service/mapper/CmsPsuPisMapper.java
@@ -123,7 +123,7 @@ public class CmsPsuPisMapper {
     private CmsPayment mapToCmsBulkPayment(List<PisPaymentData> pisPaymentDataList, String paymentProduct) {
         PisPaymentData bulkPisPaymentData = pisPaymentDataList.get(0);
         CmsBulkPayment bulkPayment = new CmsBulkPayment();
-        bulkPayment.setPaymentId(bulkPisPaymentData.getPaymentId());
+        bulkPayment.setPaymentId(bulkPisPaymentData.getPaymentData().getPaymentId());
         bulkPayment.setBatchBookingPreferred(false);
         bulkPayment.setDebtorAccount(mapToCmsAccountReference(bulkPisPaymentData.getDebtorAccount()));
         bulkPayment.setPaymentProduct(paymentProduct);


### PR DESCRIPTION
Other Endpoints are based on the Common-Payment-Id. But this id gets lost for the client. so it should be mapped on CmsBulkPayment.paymentId