### PR TITLE
Invalid Consent Request Type after update consent with dedicated accounts

### DIFF
--- a/consent-management/consent-management-lib/src/main/java/de/adorsys/psd2/consent/service/psu/CmsPsuAisServiceInternal.java
+++ b/consent-management/consent-management-lib/src/main/java/de/adorsys/psd2/consent/service/psu/CmsPsuAisServiceInternal.java
@@ -255,9 +255,10 @@ public class CmsPsuAisServiceInternal implements CmsPsuAisService {
             .ifPresent(consent::setCombinedServiceIndicator);
 
         Set<AspspAccountAccess> aspspAccountAccesses = consentMapper.mapAspspAccountAccesses(accountAccess);
+        consent.addAspspAccountAccess(aspspAccountAccesses);
         AisConsentRequestType aisConsentRequestType = aisConsentRequestTypeService.getRequestTypeFromConsent(consent);
         consent.setAisConsentRequestType(aisConsentRequestType);
-        consent.addAspspAccountAccess(aspspAccountAccesses);
+        
         consent.setExpireDate(request.getValidUntil());
         consent.setAllowedFrequencyPerDay(request.getFrequencyPerDay());
         aisConsentUsageService.resetUsage(consent);


### PR DESCRIPTION
When consent account access is updated with dedicated accounts from an status where no accounts were selected, the status stays/changes to BANK_OFFERED. With this change an Update with accounts leads to DEDICATED_ACCOUNTS