### PR TITLE
Update actions-asciidoctor Installer to v1.1.0

### DIFF
--- a/.github/workflows/develop.yaml
+++ b/.github/workflows/develop.yaml
@@ -143,7 +143,7 @@ jobs:
           ruby-version: 2.7
 
       - name: Install AsciiDoctor
-        uses: reitzig/actions-asciidoctor@v1.0.0
+        uses: reitzig/actions-asciidoctor@v1.1.0
 
       - name: Convert adoc to html
         run: cd pages && asciidoctor --failure-level WARN -R doc -D html '**/*.adoc'
@@ -159,3 +159,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./pages/html
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -146,7 +146,7 @@ jobs:
           ruby-version: 2.7
 
       - name: Install AsciiDoctor
-        uses: reitzig/actions-asciidoctor@v1.0.0
+        uses: reitzig/actions-asciidoctor@v1.1.0
 
       - name: Convert adoc to html
         run: cd pages && asciidoctor --failure-level WARN -R doc -D html '**/*.adoc'
@@ -162,3 +162,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./pages/html
+


### PR DESCRIPTION
Fixes GitHub actions 'set-env' and 'add-path' commands deprecation.

For details on the problem and its solution check the following connected issue in the installers project:
https://github.com/reitzig/actions-asciidoctor/issues/6